### PR TITLE
Do not use patterns when matching scopes.

### DIFF
--- a/src/validators/scope.lua
+++ b/src/validators/scope.lua
@@ -7,9 +7,11 @@ local function validate_scope(allowed_scopes, jwt_claims)
         return nil, "Missing required scope claim"
     end
 
-    for _, curr_scope in pairs(allowed_scopes) do
-        if string.find(jwt_claims.scope, curr_scope) then
-            return true
+    for scope in string.gmatch(jwt_claims.scope, "%S+") do
+        for _, curr_scope in pairs(allowed_scopes) do
+            if scope == curr_scope then
+                return true
+            end
         end
     end
     return nil, "Missing required scope"

--- a/tests/unit_tests/tests/validators_scope_spec.lua
+++ b/tests/unit_tests/tests/validators_scope_spec.lua
@@ -1,7 +1,7 @@
 local validate_scope = require("kong.plugins.jwt-keycloak.validators.scope").validate_scope
 
 local test_claims = {
-    scope = "profile email"
+    scope = "profile email dashed-scope"
 }
 
 describe("Validator", function()
@@ -42,6 +42,17 @@ describe("Validator", function()
         it("handle a multiple scopes", function()
             local valid, err = validate_scope({"account", "email"}, test_claims)
             assert.same(true, valid)
+        end)
+
+        it("handle pattern chars in scope", function()
+            local valid, err = validate_scope({"dashed-scope"}, test_claims)
+            assert.same(true, valid)
+        end)
+
+        it("handle partial scope match", function()
+            local valid, err = validate_scope({"dashed"}, test_claims)
+            assert.same(nil, valid)
+            assert.same("Missing required scope", err)
         end)
     end)
 end)


### PR DESCRIPTION
Fixes #23 and also fixes the case where an allowed scope is a substring of an actual scope. An example:

```
jwt_claims.scope = "my-scope another-scope"
allowed_scopes = ["scope"]
```

This would match because it's only looking for any match in the jwt scope string.