### PR TITLE
Update for unit-test to make it compatible with Kong >=2.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ include makefiles/*.mk
 
 REPOSITORY?=gbbirkisson
 IMAGE?=kong-plugin-jwt-keycloak
-KONG_VERSION?=2.3.1
+KONG_VERSION?=2.3.2
 FULL_IMAGE_NAME:=${REPOSITORY}/${IMAGE}:${KONG_VERSION}
 
 PLUGIN_VERSION?=1.1.0-1
 
-TEST_VERSIONS?=1.1.3 1.2.3 1.3.1 1.4.3 1.5.1 2.0.5 2.1.4 2.2.0
+TEST_VERSIONS?=1.1.3 1.2.3 1.3.1 1.4.3 1.5.1 2.0.5 2.1.4 2.2.0 2.3.2
 
 ### Docker ###
 

--- a/luarocks.Dockerfile
+++ b/luarocks.Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:2.3.1 as builder
+FROM kong:2.3.2 as builder
 
 USER root
 
@@ -9,7 +9,7 @@ RUN apk add --no-cache git zip && \
     luarocks install ${LUAROCKS_MODULE} && \
     luarocks pack ${LUAROCKS_MODULE}
 
-FROM kong:2.3.1
+FROM kong:2.3.2
 
 USER root
 

--- a/tests/unit_tests/Dockerfile
+++ b/tests/unit_tests/Dockerfile
@@ -1,18 +1,50 @@
-FROM ubuntu:18.04
+FROM alpine:3.12
 
-# Install openresty and luarocks
-RUN apt-get update -y && apt-get install -yqq wget software-properties-common build-essential
-RUN wget -qO - https://openresty.org/package/pubkey.gpg | apt-key add -
-RUN add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"
-RUN apt-get update -y && apt-get install -yqq openresty luarocks
+ENV LUA_VERSION=5.1.5
+ENV LUAROCKS_VERSION=3.4.0
+ENV OPENRESTY_PUB_KEY="http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub"
 
-# Install dependencies for rocks to be installed
-RUN apt-get install -yqq git libssl-dev m4 libyaml-dev zlib1g-dev
-RUN git config --global url.https://github.com/.insteadOf git://github.com/
+# Install dependencies
+RUN apk add --no-cache \
+    ca-certificates \
+    openssl \
+    curl \
+    unzip \
+    gcc \
+    git \
+    libc-dev \
+    libressl-dev \
+    yaml-dev \
+    make \
+    m4 \
+    zlib-dev \
+    bsd-compat-headers
+
+# Install openresty
+RUN wget -O "/etc/apk/keys/$(basename ${OPENRESTY_PUB_KEY})" ${OPENRESTY_PUB_KEY} \
+    && echo "http://openresty.org/package/alpine/v3.12/main" >> /etc/apk/repositories \
+    && apk update \
+    && apk add --no-cache openresty-resty 
+
+# Install Lua
+RUN wget -c https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz -O - | tar -xzf - \
+    && cd lua-${LUA_VERSION} \
+    && make -j"$(nproc)" posix \
+    && make install \
+    && cd .. \
+    && rm -rf lua-${LUA_VERSION}
+
+# Install luarocks
+RUN wget -c https://luarocks.github.io/luarocks/releases/luarocks-${LUAROCKS_VERSION}.tar.gz -O - | tar -xzf - \
+    && cd luarocks-${LUAROCKS_VERSION} \
+    && ./configure --with-lua=/usr/local \
+    && make build \
+    && make install \
+    && cd .. \
+    && rm -rf luarocks-${LUAROCKS_VERSION}
 
 # Install kong and busted
 RUN luarocks install busted
-
 ARG KONG_VERSION
 RUN luarocks install kong ${KONG_VERSION}-0
 
@@ -22,7 +54,7 @@ COPY ./LICENSE /tmp/LICENSE
 COPY ./src /tmp/src
 WORKDIR /tmp
 ARG PLUGIN_VERSION
-RUN luarocks make && luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
+RUN luarocks make 
 
 # Add custom busted binary
 COPY tests/unit_tests/busted_bin /usr/bin/busted


### PR DESCRIPTION
Current tests are failing with Kong 2.3 version because it uses a newer version of luarocks.